### PR TITLE
Update SimpleXMLReader.php

### DIFF
--- a/library/SimpleXMLReader.php
+++ b/library/SimpleXMLReader.php
@@ -108,7 +108,7 @@ class SimpleXMLReader extends XMLReader
      * @link http://php.net/manual/en/xmlreader.read.php
      * @return bool Returns TRUE on success or FALSE on failure.
      */
-    public function read()
+    public function read(): bool
     {
         $read = parent::read();       
         if ($this->depth < $this->prevDepth) {


### PR DESCRIPTION
Fix:
"PHP Deprecated:  Return type of SimpleXMLReader::read() should either be compatible with XMLReader::read(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in ..."